### PR TITLE
Fix bug for trello cards with no labels (trello returns None)

### DIFF
--- a/scriptabit/plugins/trello/trello_task.py
+++ b/scriptabit/plugins/trello/trello_task.py
@@ -76,6 +76,7 @@ class TrelloTask(Task):
         self.__card.set_closed(completed)
 
     def get_card_labels(self):
+        """ Return card labels """
         return [x.name for x in self.__card.labels] if self.__card.labels else None
 
     @property

--- a/scriptabit/plugins/trello/trello_task.py
+++ b/scriptabit/plugins/trello/trello_task.py
@@ -75,10 +75,13 @@ class TrelloTask(Task):
         """ Task completed """
         self.__card.set_closed(completed)
 
+    def get_card_labels(self):
+        return [x.name for x in self.__card.labels] if self.__card.labels else None
+
     @property
     def difficulty(self):
         """ Task difficulty """
-        card_labels = [x.name for x in self.__card.labels]
+        card_labels = self.get_card_labels()
         if card_labels:
             for dl in Difficulty:
                 if dl.name in card_labels:
@@ -95,7 +98,7 @@ class TrelloTask(Task):
     @property
     def attribute(self):
         """ Task character attribute """
-        card_labels = [x.name for x in self.__card.labels]
+        card_labels = self.get_card_labels()
         if card_labels:
             for al in CharacterAttribute:
                 if al.name in card_labels:

--- a/scriptabit/plugins/trello/trello_task_service.py
+++ b/scriptabit/plugins/trello/trello_task_service.py
@@ -58,8 +58,7 @@ class TrelloTaskService(TaskService):
                 # Check whether we can use this card or not based on the board
                 # settings: all cards or only those assigned to the current user
                 use_card = False
-
-                if 'no sync' in [l.name for l in card.labels]:
+                if card.labels and 'no sync' in [l.name for l in card.labels]:
                     use_card = False
                 elif board_defaults.all_cards:
                     use_card = True


### PR DESCRIPTION
Currently, if a card has no labels, `self.__card.labels` is `None` not `[]` which throws error.